### PR TITLE
Add Cloudflare Worker for AI spend monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.wrangler/
+.dist/
+*.log
+
+# Vitest cache
+.vitest/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,159 @@
+# AI Spend Monitor Worker
+
+A production-ready Cloudflare Worker that monitors AI usage and cost across OpenAI, Anthropic, and Google Vertex AI. The worker periodically ingests provider telemetry, normalises spend records, persists raw pages to KV, maintains rollups in a Durable Object, enforces per-provider and global spend caps, and emits alerts via Slack, email, and optional hard-cap webhooks.
+
+## Features
+
+- **Providers**
+  - OpenAI usage and cost ingestion with per-model/day aggregation.
+  - Anthropic Usage & Cost Admin API integration.
+  - Google Vertex AI spend via Cloud Billing Budgets API and/or BigQuery billing export (feature flags).
+- **Storage & scheduling**
+  - Hourly cron fetch (configurable lookback window).
+  - Raw API pages persisted to Workers KV (90-day TTL) for auditability.
+  - Durable Object rollups for atomic aggregation, cap evaluation, and alert debouncing.
+- **Cap enforcement**
+  - Per-provider and global soft/hard caps defined via environment variables.
+  - Slack + email notifications with one-hour debounce.
+  - Optional hard-cap webhook callback for external key revocation workflows.
+- **API surface (Hono)**
+  - `GET /status` – health and last ingest metadata.
+  - `GET /spend` – consolidated spend grouped by provider/model/day.
+  - `GET /providers/:name/raw` – paginated raw API responses with optional date filters.
+  - `POST /test/alert` – trigger test notifications.
+  - `POST /admin/recompute` – recompute rollups from KV raw pages (Bearer token protected).
+  - `GET /config` – redacted runtime configuration snapshot.
+- **Alerting** – Slack webhook, generic email webhook, and optional hard-cap webhook.
+- **Testing** – Vitest unit coverage for provider fetchers, cap logic, and cron orchestration.
+
+## Getting started
+
+### Prerequisites
+
+- Node.js 18+
+- `wrangler` CLI (installed via devDependencies)
+- Cloudflare account with Workers, KV, and Durable Objects access
+
+### Installation
+
+```bash
+npm install
+```
+
+### Configuration
+
+Copy `wrangler.toml` and update bindings/IDs for your environment.
+
+Configure the following secrets / variables (via `wrangler secret put` / `wrangler kv:namespace create`):
+
+| Variable | Description |
+| --- | --- |
+| `RAW_PAGES` | KV namespace used for raw provider payloads |
+| `ROLLUP_DO` | Durable Object binding (class: `RollupDO`) |
+| `OPENAI_API_KEY` | OpenAI API key |
+| `OPENAI_ORG_ID` | Optional OpenAI org id |
+| `OPENAI_PROJECT_ID` | Optional OpenAI project id filter |
+| `ANTHROPIC_API_KEY` | Anthropic API key |
+| `ANTHROPIC_ORG_ID` | Optional Anthropic org id |
+| `GCP_SA_JSON` | Google service account JSON (stringified) |
+| `GCP_BUDGET_NAME` | Budget resource path (`projects/*/billingAccounts/*/budgets/*`) |
+| `GCP_BQ_PROJECT` / `GCP_BQ_DATASET` / `GCP_BQ_TABLE` | BigQuery billing export identifiers |
+| `GCP_BILLING_ACCOUNT_ID` | Optional billing account reference |
+| `ADMIN_TOKEN` | Bearer token protecting admin routes |
+| `SLACK_WEBHOOK_URL` | Slack incoming webhook (optional) |
+| `ALERT_EMAIL_WEBHOOK` | Generic POST webhook for email alerts (optional) |
+| `ON_HARDCAP_WEBHOOK` | Hard cap webhook (optional) |
+| `*_SOFT_CAP` / `*_HARD_CAP` | USD cap thresholds for OpenAI, Anthropic, Vertex, and global |
+| `ENABLE_*` | Feature flags controlling providers |
+| `CRON_LOOKBACK_HOURS` | Lookback window (default 48) |
+
+### Provider-specific setup
+
+#### OpenAI
+
+Grant the API key access to the target organisation/project. The worker uses the Usage and Cost APIs with UTC date windows.
+
+#### Anthropic
+
+Ensure the API key has Usage & Cost Admin API permissions. Set `ANTHROPIC_ORG_ID` if required by your tenant.
+
+#### Google Vertex AI
+
+Two ingestion paths are supported (individually toggleable):
+
+1. **Budgets API** – create a Cloud Billing budget scoped to Vertex AI SKUs. Grant the service account `Billing Account Viewer` and `Budget Viewer`. Provide `GCP_BUDGET_NAME` and billing account id.
+2. **BigQuery export** – enable the detailed billing export, target dataset/table, and grant the service account `BigQuery Job User` plus dataset read access. The worker issues parameterised SQL restricted to SKUs prefixed with "Vertex AI".
+
+### Running locally
+
+```bash
+npm run dev
+```
+
+This starts `wrangler dev` with the configured bindings. Use `wrangler dev --persist-to=./data` to simulate KV/DO persistence.
+
+### Scheduled ingestion
+
+The worker registers an hourly cron (`crons = ["0 * * * *"]`). Each run:
+
+1. Fetches provider spend for the configured lookback window (48h by default).
+2. Stores each provider response in KV (TTL 90 days).
+3. Sends normalised rows to the Durable Object for aggregation + cap checks.
+4. Triggers alerts if caps are breached (with one-hour debounce).
+
+### API examples
+
+Fetch global spend grouped by provider for the past week:
+
+```bash
+curl "https://<worker-host>/spend?from=2024-01-01&to=2024-01-07&groupBy=provider"
+```
+
+Inspect raw OpenAI usage pages:
+
+```bash
+curl "https://<worker-host>/providers/openai/raw?limit=10"
+```
+
+Trigger a test alert:
+
+```bash
+curl -X POST "https://<worker-host>/test/alert"
+```
+
+Recompute rollups from KV (requires `ADMIN_TOKEN`):
+
+```bash
+curl -X POST "https://<worker-host>/admin/recompute" -H "Authorization: Bearer <token>"
+```
+
+### Testing
+
+```bash
+npm test
+```
+
+### Deployment
+
+Perform a dry-run deployment to validate bindings:
+
+```bash
+npm run deploy:dry
+```
+
+Then publish with `wrangler deploy` once configuration is complete.
+
+## Observability & logging
+
+The worker emits structured JSON logs for provider fetch duration, rollup updates, and error paths. Ensure log ingestion parses JSON for effective monitoring.
+
+## Security considerations
+
+- All secrets and tokens are sourced from environment bindings – never hard-coded.
+- Admin endpoints require a bearer token (`ADMIN_TOKEN`).
+- Responses intentionally redact secret values.
+- KV entries expire automatically after 90 days to enforce data retention.
+
+## License
+
+MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3093 @@
+{
+  "name": "ai-spend-monitor",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ai-spend-monitor",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "hono": "^4.9.7",
+        "zod": "^4.1.9"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250917.0",
+        "@types/node": "^24.5.2",
+        "miniflare": "^4.20250913.0",
+        "typescript": "^5.9.2",
+        "vitest": "^3.2.4",
+        "wrangler": "^4.37.1"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.0.tgz",
+      "integrity": "sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.7.3.tgz",
+      "integrity": "sha512-tsQQagBKjvpd9baa6nWVIv399ejiqcrUBBW6SZx6Z22+ymm+Odv5+cFimyuCsD/fC1fQTwfRmwXBNpzvHSeGCw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.21",
+        "workerd": "^1.20250828.1"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20250913.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250913.0.tgz",
+      "integrity": "sha512-926bBGIYDsF0FraaPQV0hO9LymEN+Zdkkm1qOHxU1c58oAxr5b9Tpe4d1z1EqOD0DTFhjn7V/AxKcZBaBBhO/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20250913.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250913.0.tgz",
+      "integrity": "sha512-uy5nJIt44CpICgfsKQotji31cn39i71e2KqE/zeAmmgYp/tzl2cXotVeDtynqqEsloox7hl/eBY5sU0x99N8oQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20250913.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250913.0.tgz",
+      "integrity": "sha512-khdF7MBi8L9WIt3YyWBQxipMny0J3gG824kurZiRACZmPdQ1AOzkKybDDXC3EMcF8TmGMRqKRUGQIB/25PwJuQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20250913.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250913.0.tgz",
+      "integrity": "sha512-KF5nIOt5YIYGfinY0YEe63JqaAx8WSFDHTLQpytTX+N/oJWEJu3KW6evU1TfX7o8gRlRsc0j/evcZ1vMfbDy5g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20250913.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250913.0.tgz",
+      "integrity": "sha512-m/PMnVdaUB7ymW8BvDIC5xrU16hBDCBpyf9/4y9YZSQOYTVXihxErX8kaW9H9A/I6PTX081NmxxhTbb/n+EQRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20250917.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250917.0.tgz",
+      "integrity": "sha512-Lsn9dZoRYZZCXXHZNa50cMP8kWhQZG9M7WjxNSiXFzC8bk4Wh/0SYYo4YINxEjEt6h2o69LmAhFaJ+qgaJTh8Q==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.5.tgz",
+      "integrity": "sha512-FvdDqtcRCtz6hThExcFOgW0cWX+xwSMWcRuQe5ZEb2m7cVQOAVZOIMt+/v9RxGiD9/OY16qJBXK4CVKWAPalBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.4.tgz",
+      "integrity": "sha512-iG0TIdqv8xJ3Lt9O8DrPRxw1MRLjNpoqiSGU03P/wNLP/s0ra0udPJ1J2Tx5M0J3H/cVyEgpbn8xUKRY9j59kQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.2.tgz",
+      "integrity": "sha512-m7bpKCD4QMlFCjA/nKTs23fuvoVFoA83brRKmObCUNmi/9tVu8Ve3w4YQAnJu4q3Tjf5fr685HYIC/IA2zHRSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.2.tgz",
+      "integrity": "sha512-uLN8NAiFVIRKX9ZQha8wy6UUs06UNSZ32xj6giK/rmMXAgKahwExvK6SsmgU5/brh4w/nSgj8e0k3c1HBQpa0A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.2.tgz",
+      "integrity": "sha512-oEouqQk2/zxxj22PNcGSskya+3kV0ZKH+nQxuCCOGJ4oTXBdNTbv+f/E3c74cNLeMO1S5wVWacSws10TTSB77g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.2.tgz",
+      "integrity": "sha512-OZuTVTpj3CDSIxmPgGH8en/XtirV5nfljHZ3wrNwvgkT5DQLhIKAeuFSiwtbMto6oVexV0k1F1zqURPKf5rI1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.2.tgz",
+      "integrity": "sha512-Wa/Wn8RFkIkr1vy1k1PB//VYhLnlnn5eaJkfTQKivirOvzu5uVd2It01ukeQstMursuz7S1bU+8WW+1UPXpa8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.2.tgz",
+      "integrity": "sha512-QkzxvH3kYN9J1w7D1A+yIMdI1pPekD+pWx7G5rXgnIlQ1TVYVC6hLl7SOV9pi5q9uIDF9AuIGkuzcbF7+fAhow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.2.tgz",
+      "integrity": "sha512-dkYXB0c2XAS3a3jmyDkX4Jk0m7gWLFzq1C3qUnJJ38AyxIF5G/dyS4N9B30nvFseCfgtCEdbYFhk0ChoCGxPog==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.2.tgz",
+      "integrity": "sha512-9VlPY/BN3AgbukfVHAB8zNFWB/lKEuvzRo1NKev0Po8sYFKx0i+AQlCYftgEjcL43F2h9Ui1ZSdVBc4En/sP2w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.2.tgz",
+      "integrity": "sha512-+GdKWOvsifaYNlIVf07QYan1J5F141+vGm5/Y8b9uCZnG/nxoGqgCmR24mv0koIWWuqvFYnbURRqw1lv7IBINw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.2.tgz",
+      "integrity": "sha512-df0Eou14ojtUdLQdPFnymEQteENwSJAdLf5KCDrmZNsy1c3YaCNaJvYsEUHnrg+/DLBH612/R0xd3dD03uz2dg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.2.tgz",
+      "integrity": "sha512-iPeouV0UIDtz8j1YFR4OJ/zf7evjauqv7jQ/EFs0ClIyL+by++hiaDAfFipjOgyz6y6xbDvJuiU4HwpVMpRFDQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.50.2.tgz",
+      "integrity": "sha512-OL6KaNvBopLlj5fTa5D5bau4W82f+1TyTZRr2BdnfsrnQnmdxh4okMxR2DcDkJuh4KeoQZVuvHvzuD/lyLn2Kw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.2.tgz",
+      "integrity": "sha512-I21VJl1w6z/K5OTRl6aS9DDsqezEZ/yKpbqlvfHbW0CEF5IL8ATBMuUx6/mp683rKTK8thjs/0BaNrZLXetLag==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.2.tgz",
+      "integrity": "sha512-Hq6aQJT/qFFHrYMjS20nV+9SKrXL2lvFBENZoKfoTH2kKDOJqff5OSJr4x72ZaG/uUn+XmBnGhfr4lwMRrmqCQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.2.tgz",
+      "integrity": "sha512-82rBSEXRv5qtKyr0xZ/YMF531oj2AIpLZkeNYxmKNN6I2sVE9PGegN99tYDLK2fYHJITL1P2Lgb4ZXnv0PjQvw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.2.tgz",
+      "integrity": "sha512-4Q3S3Hy7pC6uaRo9gtXUTJ+EKo9AKs3BXKc2jYypEcMQ49gDPFU2P1ariX9SEtBzE5egIX6fSUmbmGazwBVF9w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.2.tgz",
+      "integrity": "sha512-9Jie/At6qk70dNIcopcL4p+1UirusEtznpNtcq/u/C5cC4HBX7qSGsYIcG6bdxj15EYWhHiu02YvmdPzylIZlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.2.tgz",
+      "integrity": "sha512-HPNJwxPL3EmhzeAnsWQCM3DcoqOz3/IC6de9rWfGR8ZCuEHETi9km66bH/wG3YH0V3nyzyFEGUZeL5PKyy4xvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.2.tgz",
+      "integrity": "sha512-nMKvq6FRHSzYfKLHZ+cChowlEkR2lj/V0jYj9JnGUVPL2/mIeFGmVM2mLaFeNa5Jev7W7TovXqXIG2d39y1KYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.2.tgz",
+      "integrity": "sha512-eFUvvnTYEKeTyHEijQKz81bLrUQOXKZqECeiWH6tb8eXXbZk+CXSG2aFrig2BQ/pjiVRj36zysjgILkqarS2YA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.2.tgz",
+      "integrity": "sha512-cBaWmXqyfRhH8zmUxK3d3sAhEWLrtMjWBRwdMMHJIXSjvjLKvv49adxiEz+FJ8AP90apSDDBx2Tyd/WylV6ikA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.2.tgz",
+      "integrity": "sha512-APwKy6YUhvZaEoHyM+9xqmTpviEI+9eL7LoCH+aLcvWYHJ663qG5zx7WzWZY+a9qkg5JtzcMyJ9z0WtQBMDmgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.1.0.tgz",
+      "integrity": "sha512-7F/yz2IphV39hiS2zB4QYVkivrptHHh0K8qJJd9HhuWSdvf8AN7NpebW3CcDZDBQsUPMoDKWsY2WWgW7bqOcfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.7.tgz",
+      "integrity": "sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.12.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
+      "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/exit-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
+      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/exsolve": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
+      "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/hono": {
+      "version": "4.9.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.9.7.tgz",
+      "integrity": "sha512-t4Te6ERzIaC48W3x4hJmBwgNlLhmiEdEE5ViYb02ffw4ignHNHa5IBtPjmbKstmtKa8X6C35iWwK4HaqvrzG9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20250913.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250913.0.tgz",
+      "integrity": "sha512-EwlUOxtvb9UKg797YZMCtNga/VSAnKG/kbJX9YGqXJoAJjDhDeAeqyCWjSl9O6EzCZNhtHuW7ZV0pD5Hec617g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "acorn": "8.14.0",
+        "acorn-walk": "8.3.2",
+        "exit-hook": "2.2.1",
+        "glob-to-regexp": "0.4.1",
+        "sharp": "^0.33.5",
+        "stoppable": "1.1.0",
+        "undici": "7.14.0",
+        "workerd": "1.20250913.0",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10",
+        "zod": "3.22.3"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/miniflare/node_modules/zod": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.2.tgz",
+      "integrity": "sha512-BgLRGy7tNS9H66aIMASq1qSYbAAJV6Z6WR4QYTvj5FgF15rZ/ympT1uixHXwzbZUBDbkvqUI1KR0fH1FhMaQ9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.50.2",
+        "@rollup/rollup-android-arm64": "4.50.2",
+        "@rollup/rollup-darwin-arm64": "4.50.2",
+        "@rollup/rollup-darwin-x64": "4.50.2",
+        "@rollup/rollup-freebsd-arm64": "4.50.2",
+        "@rollup/rollup-freebsd-x64": "4.50.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.50.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.50.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.50.2",
+        "@rollup/rollup-linux-arm64-musl": "4.50.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.50.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.50.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.50.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.50.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.50.2",
+        "@rollup/rollup-linux-x64-gnu": "4.50.2",
+        "@rollup/rollup-linux-x64-musl": "4.50.2",
+        "@rollup/rollup-openharmony-arm64": "4.50.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.50.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.50.2",
+        "@rollup/rollup-win32-x64-msvc": "4.50.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
+      "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
+      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
+      "integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.21",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.21.tgz",
+      "integrity": "sha512-Wj7/AMtE9MRnAXa6Su3Lk0LNCfqDYgfwVjwRFVum9U7wsto1imuHqk4kTm7Jni+5A0Hn7dttL6O/zjvUvoo+8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "exsolve": "^1.0.7",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.5.tgz",
+      "integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20250913.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250913.0.tgz",
+      "integrity": "sha512-y3J1NjCL10SAWDwgGdcNSRyOVod/dWNypu64CCdjj8VS4/k+Ofa/fHaJGC1stbdzAB1tY2P35Ckgm1PU5HKWiw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20250913.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20250913.0",
+        "@cloudflare/workerd-linux-64": "1.20250913.0",
+        "@cloudflare/workerd-linux-arm64": "1.20250913.0",
+        "@cloudflare/workerd-windows-64": "1.20250913.0"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.37.1",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.37.1.tgz",
+      "integrity": "sha512-ntm1OsIB2r/f7b5bfS84Lzz5QEx3zn4vUsn1JOVz/+7bw8triyytnxbp68OwOimF1vL5A9sQ0Nd+L6u8F3hECg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.4.0",
+        "@cloudflare/unenv-preset": "2.7.3",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.25.4",
+        "miniflare": "4.20250913.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.21",
+        "workerd": "1.20250913.0"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20250913.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.4.tgz",
+      "integrity": "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.4.tgz",
+      "integrity": "sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.4.tgz",
+      "integrity": "sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.4.tgz",
+      "integrity": "sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.4.tgz",
+      "integrity": "sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.4.tgz",
+      "integrity": "sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.4.tgz",
+      "integrity": "sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.4.tgz",
+      "integrity": "sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.4.tgz",
+      "integrity": "sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.4.tgz",
+      "integrity": "sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.4.tgz",
+      "integrity": "sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.4.tgz",
+      "integrity": "sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.4.tgz",
+      "integrity": "sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.4.tgz",
+      "integrity": "sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.4.tgz",
+      "integrity": "sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.4.tgz",
+      "integrity": "sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.4.tgz",
+      "integrity": "sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.4.tgz",
+      "integrity": "sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.4.tgz",
+      "integrity": "sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.4.tgz",
+      "integrity": "sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.4.tgz",
+      "integrity": "sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.4.tgz",
+      "integrity": "sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.4.tgz",
+      "integrity": "sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.4.tgz",
+      "integrity": "sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.4.tgz",
+      "integrity": "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.4.tgz",
+      "integrity": "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.4",
+        "@esbuild/android-arm": "0.25.4",
+        "@esbuild/android-arm64": "0.25.4",
+        "@esbuild/android-x64": "0.25.4",
+        "@esbuild/darwin-arm64": "0.25.4",
+        "@esbuild/darwin-x64": "0.25.4",
+        "@esbuild/freebsd-arm64": "0.25.4",
+        "@esbuild/freebsd-x64": "0.25.4",
+        "@esbuild/linux-arm": "0.25.4",
+        "@esbuild/linux-arm64": "0.25.4",
+        "@esbuild/linux-ia32": "0.25.4",
+        "@esbuild/linux-loong64": "0.25.4",
+        "@esbuild/linux-mips64el": "0.25.4",
+        "@esbuild/linux-ppc64": "0.25.4",
+        "@esbuild/linux-riscv64": "0.25.4",
+        "@esbuild/linux-s390x": "0.25.4",
+        "@esbuild/linux-x64": "0.25.4",
+        "@esbuild/netbsd-arm64": "0.25.4",
+        "@esbuild/netbsd-x64": "0.25.4",
+        "@esbuild/openbsd-arm64": "0.25.4",
+        "@esbuild/openbsd-x64": "0.25.4",
+        "@esbuild/sunos-x64": "0.25.4",
+        "@esbuild/win32-arm64": "0.25.4",
+        "@esbuild/win32-ia32": "0.25.4",
+        "@esbuild/win32-x64": "0.25.4"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.9.tgz",
+      "integrity": "sha512-HI32jTq0AUAC125z30E8bQNz0RQ+9Uc+4J7V97gLYjZVKRjeydPgGt6dvQzFrav7MYOUGFqqOGiHpA/fdbd0cQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
   },
   "dependencies": {
     "hono": "^4.9.7",
-    "zod": "^4.1.9"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250917.0",
     "@types/node": "^24.5.2",
     "miniflare": "^4.20250913.0",
     "typescript": "^5.9.2",
-    "vitest": "^3.2.4",
+    "vitest": "^1.6.0",
     "wrangler": "^4.37.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "ai-spend-monitor",
+  "version": "1.0.0",
+  "description": "Cloudflare Worker to monitor AI spend across OpenAI, Anthropic, and Google Vertex AI.",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "test": "vitest",
+    "check": "tsc --noEmit",
+    "deploy:dry": "wrangler deploy --dry-run"
+  },
+  "dependencies": {
+    "hono": "^4.9.7",
+    "zod": "^4.1.9"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250917.0",
+    "@types/node": "^24.5.2",
+    "miniflare": "^4.20250913.0",
+    "typescript": "^5.9.2",
+    "vitest": "^3.2.4",
+    "wrangler": "^4.37.1"
+  }
+}

--- a/src/core/alerts.ts
+++ b/src/core/alerts.ts
@@ -1,0 +1,111 @@
+import { AlertChannels, AlertContext, AlertResult, CapBreach } from './types';
+import { shouldSendAlert, updateAlertTimestamps } from './caps';
+
+export interface DispatchOptions {
+  channels: AlertChannels;
+  hardCapWebhook?: string;
+  lastSent: Record<string, string>;
+  fetchImpl?: typeof fetch;
+  debounceMs?: number;
+}
+
+export interface DispatchResult {
+  results: AlertResult[];
+  lastSent: Record<string, string>;
+}
+
+const formatBreachLine = (breach: CapBreach): string => {
+  const level = breach.level === 'soft' ? 'Soft cap' : 'Hard cap';
+  return `${level} breached for ${breach.scope}: $${breach.total.toFixed(2)} (threshold $${breach.threshold.toFixed(2)})`;
+};
+
+const buildAlertMessage = (breaches: CapBreach[], now: Date): string => {
+  const header = `AI spend monitor detected ${breaches.length} cap breach${breaches.length === 1 ? '' : 'es'} at ${now.toISOString()}`;
+  const lines = breaches.map((breach) => `• ${formatBreachLine(breach)}`);
+  return [header, ...lines].join('\n');
+};
+
+const buildAlertHtml = (breaches: CapBreach[], now: Date): string => {
+  const items = breaches
+    .map((breach) => `<li><strong>${breach.scope}</strong> ${breach.level.toUpperCase()} &mdash; $${breach.total.toFixed(2)} (threshold $${breach.threshold.toFixed(2)})</li>`)
+    .join('');
+  return `<p>AI spend monitor detected ${breaches.length} cap breach${breaches.length === 1 ? '' : 'es'} at ${now.toISOString()}.</p><ul>${items}</ul>`;
+};
+
+const postJson = async (url: string, body: unknown, fetchImpl: typeof fetch): Promise<boolean> => {
+  const response = await fetchImpl(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return response.ok;
+};
+
+export const dispatchCapAlerts = async (
+  context: AlertContext,
+  options: DispatchOptions,
+  now: Date,
+): Promise<DispatchResult> => {
+  const debounceMs = options.debounceMs ?? 60 * 60 * 1000;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const toNotify = shouldSendAlert(context.breaches, options.lastSent, now, debounceMs);
+
+  if (toNotify.length === 0) {
+    return { results: [], lastSent: options.lastSent };
+  }
+
+  const results: AlertResult[] = [];
+  const message = buildAlertMessage(toNotify, now);
+  const html = buildAlertHtml(toNotify, now);
+
+  if (options.channels.slackWebhook) {
+    const ok = await postJson(
+      options.channels.slackWebhook,
+      {
+        text: message,
+        blocks: [
+          { type: 'section', text: { type: 'mrkdwn', text: `*AI spend monitor alert*\n${message}` } },
+          {
+            type: 'context',
+            elements: toNotify.map((breach) => ({
+              type: 'mrkdwn',
+              text: formatBreachLine(breach),
+            })),
+          },
+        ],
+      },
+      fetchImpl,
+    );
+    results.push({ channel: 'slack', ok });
+  }
+
+  if (options.channels.emailWebhook) {
+    const ok = await postJson(
+      options.channels.emailWebhook,
+      {
+        subject: '[AI Spend Monitor] Cap breach detected',
+        text: message,
+        html,
+      },
+      fetchImpl,
+    );
+    results.push({ channel: 'email', ok });
+  }
+
+  const hardBreaches = toNotify.filter((breach) => breach.level === 'hard');
+  if (hardBreaches.length > 0 && options.hardCapWebhook) {
+    await postJson(
+      options.hardCapWebhook,
+      {
+        event: 'ai_spend_hard_cap',
+        breaches: hardBreaches,
+        totals: context.totals,
+        triggeredAt: now.toISOString(),
+      },
+      fetchImpl,
+    );
+  }
+
+  const updated = updateAlertTimestamps(options.lastSent, toNotify, now);
+  return { results, lastSent: updated };
+};

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -1,0 +1,18 @@
+import { HTTPException } from 'hono/http-exception';
+import { createMiddleware } from 'hono/factory';
+
+export const requireAdmin = (token?: string) =>
+  createMiddleware(async (c, next) => {
+    if (!token) {
+      throw new HTTPException(500, { message: 'ADMIN_TOKEN not configured' });
+    }
+    const auth = c.req.header('Authorization');
+    if (!auth || !auth.startsWith('Bearer ')) {
+      throw new HTTPException(401, { message: 'Missing bearer token' });
+    }
+    const provided = auth.substring('Bearer '.length);
+    if (provided !== token) {
+      throw new HTTPException(403, { message: 'Invalid bearer token' });
+    }
+    await next();
+  });

--- a/src/core/caps.ts
+++ b/src/core/caps.ts
@@ -1,0 +1,86 @@
+import { CapBreach, CapConfig, CapEvaluationResult, CapScope, SpendRow } from './types';
+import { monthToDateRows } from './rollups';
+
+const providerScopes: CapScope[] = ['openai', 'anthropic', 'vertex'];
+
+const capKey = (scope: CapScope, level: 'soft' | 'hard'): string => `${scope}:${level}`;
+
+export const evaluateCaps = (rows: SpendRow[], caps: CapConfig, now: Date): CapEvaluationResult => {
+  const monthRows = monthToDateRows(rows, now);
+  const totals: Record<CapScope, number> = {
+    openai: 0,
+    anthropic: 0,
+    vertex: 0,
+    global: 0,
+  };
+
+  for (const row of monthRows) {
+    totals[row.provider] += row.cost_usd;
+    totals.global += row.cost_usd;
+  }
+
+  const breaches: CapBreach[] = [];
+  const pushBreach = (scope: CapScope, level: 'soft' | 'hard', threshold: number): void => {
+    if (!threshold) return;
+    const total = totals[scope];
+    if (total >= threshold) {
+      breaches.push({
+        scope,
+        level,
+        threshold,
+        total,
+        triggeredAt: now.toISOString(),
+      });
+    }
+  };
+
+  const scopeCaps: Record<CapScope, { soft: number; hard: number }> = {
+    openai: { soft: caps.openaiSoft, hard: caps.openaiHard },
+    anthropic: { soft: caps.anthropicSoft, hard: caps.anthropicHard },
+    vertex: { soft: caps.vertexSoft, hard: caps.vertexHard },
+    global: { soft: caps.globalSoft, hard: caps.globalHard },
+  };
+
+  for (const scope of providerScopes) {
+    pushBreach(scope, 'soft', scopeCaps[scope].soft);
+    pushBreach(scope, 'hard', scopeCaps[scope].hard);
+  }
+  pushBreach('global', 'soft', scopeCaps.global.soft);
+  pushBreach('global', 'hard', scopeCaps.global.hard);
+
+  return { totals, breaches };
+};
+
+export const shouldSendAlert = (
+  breaches: CapBreach[],
+  lastSent: Record<string, string>,
+  now: Date,
+  debounceMs: number,
+): CapBreach[] => {
+  const eligible: CapBreach[] = [];
+  for (const breach of breaches) {
+    const key = capKey(breach.scope, breach.level);
+    const last = lastSent[key];
+    if (!last) {
+      eligible.push(breach);
+      continue;
+    }
+    const lastDate = new Date(last);
+    if (now.getTime() - lastDate.getTime() >= debounceMs) {
+      eligible.push(breach);
+    }
+  }
+  return eligible;
+};
+
+export const updateAlertTimestamps = (
+  lastSent: Record<string, string>,
+  breaches: CapBreach[],
+  now: Date,
+): Record<string, string> => {
+  const updated = { ...lastSent };
+  for (const breach of breaches) {
+    updated[capKey(breach.scope, breach.level)] = now.toISOString();
+  }
+  return updated;
+};

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -1,0 +1,35 @@
+import type { FetchWithRetryArgs } from './types';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export const fetchWithRetry = async <T = unknown>({
+  request,
+  init,
+  fetchImpl,
+  maxRetries = 3,
+  initialDelayMs = 500,
+}: FetchWithRetryArgs): Promise<Response> => {
+  const fn = fetchImpl ?? fetch;
+  let attempt = 0;
+  let delay = initialDelayMs;
+  while (true) {
+    const response = await fn(request, init);
+    if (!response.status || response.status < 500 || response.status >= 600) {
+      return response;
+    }
+    attempt += 1;
+    if (attempt > maxRetries) {
+      return response;
+    }
+    await sleep(delay);
+    delay *= 2;
+  }
+};
+
+export const parseJsonResponse = async <T>(response: Response): Promise<T> => {
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`HTTP ${response.status}: ${text}`);
+  }
+  return (await response.json()) as T;
+};

--- a/src/core/rollups.ts
+++ b/src/core/rollups.ts
@@ -1,0 +1,130 @@
+import { GroupByOption, ProviderName, SpendRow } from './types';
+
+export interface SpendAggregation {
+  key: string;
+  provider?: ProviderName | 'global';
+  model?: string;
+  day?: string;
+  cost_usd: number;
+  input_tokens?: number;
+  output_tokens?: number;
+  currency: 'USD';
+  rows: SpendRow[];
+}
+
+const RETENTION_DAYS = 90;
+
+export const formatUtcDate = (date: Date): string => {
+  const year = date.getUTCFullYear();
+  const month = `${date.getUTCMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getUTCDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+export const makeRowKey = (row: SpendRow): string =>
+  `${row.provider}|${row.day}|${row.model ?? ''}`;
+
+export const pruneRows = (rows: SpendRow[], now: Date, retentionDays = RETENTION_DAYS): SpendRow[] => {
+  const cutoff = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  cutoff.setUTCDate(cutoff.getUTCDate() - retentionDays);
+  const cutoffStr = formatUtcDate(cutoff);
+  return rows.filter((row) => row.day >= cutoffStr);
+};
+
+export const upsertRows = (existing: SpendRow[], incoming: SpendRow[], now: Date): SpendRow[] => {
+  const merged = new Map<string, SpendRow>();
+  for (const row of existing) {
+    merged.set(makeRowKey(row), row);
+  }
+  for (const row of incoming) {
+    merged.set(makeRowKey(row), row);
+  }
+  return pruneRows(Array.from(merged.values()), now).sort((a, b) => a.day.localeCompare(b.day));
+};
+
+export const filterRowsByRange = (rows: SpendRow[], from?: string, to?: string): SpendRow[] => {
+  return rows.filter((row) => {
+    if (from && row.day < from) return false;
+    if (to && row.day > to) return false;
+    return true;
+  });
+};
+
+const accumulate = (target: SpendAggregation, row: SpendRow): void => {
+  target.cost_usd += row.cost_usd;
+  if (row.input_tokens) {
+    target.input_tokens = (target.input_tokens ?? 0) + row.input_tokens;
+  }
+  if (row.output_tokens) {
+    target.output_tokens = (target.output_tokens ?? 0) + row.output_tokens;
+  }
+  target.rows.push(row);
+};
+
+export const aggregateRows = (rows: SpendRow[], groupBy?: GroupByOption): SpendAggregation[] => {
+  if (!groupBy) {
+    return rows.map((row) => ({
+      key: makeRowKey(row),
+      provider: row.provider,
+      model: row.model,
+      day: row.day,
+      cost_usd: row.cost_usd,
+      input_tokens: row.input_tokens,
+      output_tokens: row.output_tokens,
+      currency: row.currency,
+      rows: [row],
+    }));
+  }
+
+  const aggregates = new Map<string, SpendAggregation>();
+
+  for (const row of rows) {
+    let key: string;
+    const template: Partial<SpendAggregation> = {};
+
+    switch (groupBy) {
+      case 'provider':
+        key = row.provider;
+        template.provider = row.provider;
+        break;
+      case 'day':
+        key = row.day;
+        template.day = row.day;
+        template.provider = 'global';
+        break;
+      case 'model':
+        key = `${row.provider}:${row.model ?? 'unknown'}`;
+        template.provider = row.provider;
+        template.model = row.model;
+        break;
+      default:
+        key = makeRowKey(row);
+        template.provider = row.provider;
+        template.model = row.model;
+        template.day = row.day;
+    }
+
+    const existing = aggregates.get(key);
+    if (!existing) {
+      aggregates.set(key, {
+        key,
+        cost_usd: 0,
+        currency: 'USD',
+        rows: [],
+        ...(template.provider ? { provider: template.provider } : {}),
+        ...(template.model ? { model: template.model } : {}),
+        ...(template.day ? { day: template.day } : {}),
+      });
+    }
+    accumulate(aggregates.get(key)! , row);
+  }
+
+  return Array.from(aggregates.values()).sort((a, b) => a.key.localeCompare(b.key));
+};
+
+export const monthToDateRows = (rows: SpendRow[], now: Date): SpendRow[] => {
+  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+  const startStr = formatUtcDate(start);
+  const todayStr = formatUtcDate(now);
+  return filterRowsByRange(rows, startStr, todayStr);
+};

--- a/src/core/storage.ts
+++ b/src/core/storage.ts
@@ -1,0 +1,192 @@
+import type { DurableObjectState } from '@cloudflare/workers-types';
+import type { KVNamespace } from '@cloudflare/workers-types';
+import { aggregateRows, filterRowsByRange, upsertRows } from './rollups';
+import { dispatchCapAlerts } from './alerts';
+import { evaluateCaps } from './caps';
+import type {
+  AlertChannels,
+  CapConfig,
+  CapEvaluationResult,
+  ProviderName,
+  ProviderRawPage,
+  SpendRow,
+} from './types';
+
+const RAW_PREFIX = 'raw';
+const RETENTION_TTL_SECONDS = 90 * 24 * 60 * 60; // 90 days
+
+type Cursor = string | undefined;
+
+export interface RawPageListResult<T = unknown> {
+  items: ProviderRawPage<T>[];
+  cursor?: Cursor;
+}
+
+export class RawPageStore {
+  constructor(private readonly kv: KVNamespace) {}
+
+  private buildKey(provider: ProviderName, id: string): string {
+    return `${RAW_PREFIX}/${provider}/${id}`;
+  }
+
+  async put(page: ProviderRawPage): Promise<void> {
+    const key = this.buildKey(page.provider, page.id);
+    await this.kv.put(key, JSON.stringify(page), { expirationTtl: RETENTION_TTL_SECONDS });
+  }
+
+  async list(provider: ProviderName, cursor?: Cursor, limit = 50): Promise<RawPageListResult> {
+    const prefix = `${RAW_PREFIX}/${provider}/`;
+    const res = await this.kv.list({ prefix, cursor, limit });
+    const items: ProviderRawPage[] = [];
+    for (const key of res.keys) {
+      const value = await this.kv.get<ProviderRawPage>(key.name, 'json');
+      if (value) {
+        items.push(value);
+      }
+    }
+    return {
+      items,
+      cursor: res.list_complete ? undefined : res.cursor,
+    };
+  }
+
+  async getAll(): Promise<ProviderRawPage[]> {
+    let cursor: string | undefined;
+    const items: ProviderRawPage[] = [];
+    do {
+      const res = await this.kv.list({ prefix: `${RAW_PREFIX}/`, cursor, limit: 1000 });
+      for (const key of res.keys) {
+        const value = await this.kv.get<ProviderRawPage>(key.name, 'json');
+        if (value) items.push(value);
+      }
+      cursor = res.list_complete ? undefined : res.cursor;
+    } while (cursor);
+    return items;
+  }
+}
+
+interface RollupState {
+  rows: SpendRow[];
+  lastRun?: string;
+  lastError?: string | null;
+  lastAlerts: Record<string, string>;
+  lastCapEvaluation?: CapEvaluationResult;
+}
+
+interface UpdatePayload {
+  rows: SpendRow[];
+  nowIso: string;
+  caps: CapConfig;
+  replace?: boolean;
+  lastError?: string | null;
+  channels?: AlertChannels;
+  hardCapWebhook?: string;
+}
+
+export interface RollupResponse {
+  rows: SpendRow[];
+  lastRun?: string;
+  lastError?: string | null;
+  evaluation?: CapEvaluationResult;
+}
+
+const defaultState: RollupState = {
+  rows: [],
+  lastAlerts: {},
+};
+
+export class RollupDO {
+  private stateData: RollupState = { ...defaultState };
+  private ready: Promise<void>;
+
+  constructor(private readonly state: DurableObjectState) {
+    this.ready = this.state.blockConcurrencyWhile(async () => {
+      const stored = await this.state.storage.get<RollupState>('state');
+      if (stored) {
+        this.stateData = stored;
+      }
+    });
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    await this.ready;
+    const url = new URL(request.url);
+    switch (url.pathname) {
+      case '/update':
+        if (request.method !== 'POST') break;
+        return this.handleUpdate(request);
+      case '/state':
+        if (request.method !== 'GET') break;
+        return Response.json(this.serialize());
+      case '/spend':
+        if (request.method !== 'GET') break;
+        return this.handleSpend(url);
+      default:
+        break;
+    }
+    return new Response('Not found', { status: 404 });
+  }
+
+  private serialize(): RollupResponse {
+    return {
+      rows: this.stateData.rows,
+      lastRun: this.stateData.lastRun,
+      lastError: this.stateData.lastError,
+      evaluation: this.stateData.lastCapEvaluation,
+    };
+  }
+
+  private async handleUpdate(request: Request): Promise<Response> {
+    const payload = (await request.json()) as UpdatePayload;
+    const now = new Date(payload.nowIso ?? new Date().toISOString());
+    const incoming = payload.rows ?? [];
+
+    if (payload.replace) {
+      this.stateData.rows = upsertRows([], incoming, now);
+    } else {
+      this.stateData.rows = upsertRows(this.stateData.rows, incoming, now);
+    }
+
+    this.stateData.lastRun = payload.nowIso;
+    if (payload.lastError !== undefined) {
+      this.stateData.lastError = payload.lastError;
+    }
+
+    const evaluation = evaluateCaps(this.stateData.rows, payload.caps, now);
+    this.stateData.lastCapEvaluation = evaluation;
+
+    if (payload.channels || payload.hardCapWebhook) {
+      const result = await dispatchCapAlerts(
+        { breaches: evaluation.breaches, totals: evaluation.totals },
+        {
+          channels: payload.channels ?? {},
+          hardCapWebhook: payload.hardCapWebhook,
+          lastSent: this.stateData.lastAlerts,
+        },
+        now,
+      );
+      this.stateData.lastAlerts = result.lastSent;
+    }
+
+    await this.persist();
+    return Response.json(this.serialize());
+  }
+
+  private async persist(): Promise<void> {
+    await this.state.storage.put('state', this.stateData);
+  }
+
+  private handleSpend(url: URL): Response {
+    const from = url.searchParams.get('from') ?? undefined;
+    const to = url.searchParams.get('to') ?? undefined;
+    const groupBy = (url.searchParams.get('groupBy') ?? undefined) as
+      | 'model'
+      | 'provider'
+      | 'day'
+      | undefined;
+
+    const filtered = filterRowsByRange(this.stateData.rows, from, to);
+    const aggregates = aggregateRows(filtered, groupBy);
+    return Response.json({ groupBy, aggregates });
+  }
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,114 @@
+export type ProviderName = 'openai' | 'anthropic' | 'vertex';
+
+export type SpendSource = 'usage_api' | 'cost_api' | 'bq_export' | 'budgets_api';
+
+export interface SpendRow {
+  provider: ProviderName;
+  model?: string;
+  day: string; // YYYY-MM-DD in UTC
+  input_tokens?: number;
+  output_tokens?: number;
+  cost_usd: number;
+  currency: 'USD';
+  source: SpendSource;
+}
+
+export interface ProviderFetchOptions {
+  from: string; // inclusive YYYY-MM-DD
+  to: string; // inclusive YYYY-MM-DD
+  fetchImpl?: typeof fetch;
+}
+
+export interface ProviderRawPage<T = unknown> {
+  id: string;
+  provider: ProviderName;
+  fetchedAt: string; // ISO timestamp
+  window: { from: string; to: string };
+  payload: T;
+  meta?: Record<string, unknown>;
+}
+
+export interface ProviderResult<T = unknown> {
+  rows: SpendRow[];
+  rawPages: ProviderRawPage<T>[];
+}
+
+export type GroupByOption = 'model' | 'provider' | 'day';
+
+export interface CapConfig {
+  openaiSoft: number;
+  openaiHard: number;
+  anthropicSoft: number;
+  anthropicHard: number;
+  vertexSoft: number;
+  vertexHard: number;
+  globalSoft: number;
+  globalHard: number;
+}
+
+export type CapScope = ProviderName | 'global';
+
+export interface CapThreshold {
+  scope: CapScope;
+  soft: number;
+  hard: number;
+}
+
+export interface CapBreach {
+  scope: CapScope;
+  level: 'soft' | 'hard';
+  threshold: number;
+  total: number;
+  triggeredAt: string;
+}
+
+export interface CapEvaluationResult {
+  totals: Record<CapScope, number>;
+  breaches: CapBreach[];
+}
+
+export interface RollupSummary {
+  rows: SpendRow[];
+  lastRun?: string;
+  lastError?: string | null;
+  totalsByProvider: Record<ProviderName, number>;
+  globalTotal: number;
+  capBreaches: CapBreach[];
+}
+
+export interface AlertContext {
+  breaches: CapBreach[];
+  totals: Record<CapScope, number>;
+}
+
+export interface AlertChannels {
+  slackWebhook?: string;
+  emailWebhook?: string;
+}
+
+export interface AlertResult {
+  channel: 'slack' | 'email';
+  ok: boolean;
+}
+
+export interface OAuthTokenResponse {
+  access_token: string;
+  expires_in: number;
+  token_type: string;
+}
+
+export interface BudgetCost {
+  currentCost: number;
+  forecastedCost?: number;
+}
+
+export interface FetchRetryOptions {
+  maxRetries?: number;
+  initialDelayMs?: number;
+}
+
+export interface FetchWithRetryArgs extends FetchRetryOptions {
+  request: RequestInfo;
+  init?: RequestInit;
+  fetchImpl?: typeof fetch;
+}

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -1,0 +1,148 @@
+import type { ScheduledEvent } from '@cloudflare/workers-types';
+import { loadConfig } from './env';
+import { RawPageStore } from './core/storage';
+import { formatUtcDate } from './core/rollups';
+import { fetchOpenAISpend } from './providers/openai';
+import { fetchAnthropicSpend } from './providers/anthropic';
+import { fetchVertexSpendViaBudget } from './providers/gcp_billing';
+import { fetchVertexSpendViaBigQuery } from './providers/gcp_bigquery';
+import type { ProviderRawPage, ProviderResult, SpendRow } from './core/types';
+
+const log = (entry: Record<string, unknown>) => {
+  console.log(JSON.stringify(entry));
+};
+
+const errorLog = (entry: Record<string, unknown>) => {
+  console.error(JSON.stringify(entry));
+};
+
+const collectRows = async <T>(
+  name: string,
+  fetcher: () => Promise<ProviderResult<T>>,
+): Promise<ProviderResult<T>> => {
+  const start = Date.now();
+  try {
+    const result = await fetcher();
+    log({ level: 'info', provider: name, op: 'fetch', duration_ms: Date.now() - start, rows: result.rows.length });
+    return result;
+  } catch (err) {
+    errorLog({ level: 'error', provider: name, op: 'fetch', message: (err as Error).message });
+    throw err;
+  }
+};
+
+export const handleScheduled = async (event: ScheduledEvent, env: any, ctx: ExecutionContext): Promise<void> => {
+  const config = loadConfig(env);
+  const now = new Date(event.scheduledTime ?? Date.now());
+  const lookbackHours = config.cronLookbackHours;
+  const fromDate = new Date(now.getTime() - lookbackHours * 60 * 60 * 1000);
+  const from = formatUtcDate(fromDate);
+  const to = formatUtcDate(now);
+  const rawStore = new RawPageStore(config.RAW_PAGES);
+  const rows: SpendRow[] = [];
+  const rawPages: ProviderRawPage[] = [];
+
+  try {
+    if (config.flags.openai && config.openai.apiKey) {
+      const result = await collectRows('openai', () =>
+        fetchOpenAISpend(
+          {
+            apiKey: config.openai.apiKey!,
+            orgId: config.openai.orgId,
+            projectId: config.openai.projectId,
+          },
+          { from, to },
+        ),
+      );
+      rows.push(...result.rows);
+      rawPages.push(...result.rawPages);
+    }
+
+    if (config.flags.anthropic && config.anthropic.apiKey) {
+      const result = await collectRows('anthropic', () =>
+        fetchAnthropicSpend(
+          {
+            apiKey: config.anthropic.apiKey!,
+            orgId: config.anthropic.orgId,
+          },
+          { from, to },
+        ),
+      );
+      rows.push(...result.rows);
+      rawPages.push(...result.rawPages);
+    }
+
+    if (config.flags.vertexBillingApi && config.gcp.serviceAccount && config.gcp.budgetName) {
+      const result = await collectRows('vertex-budgets', () =>
+        fetchVertexSpendViaBudget(
+          {
+            serviceAccountJson: config.gcp.serviceAccount!,
+            budgetName: config.gcp.budgetName!,
+          },
+          { from, to },
+        ),
+      );
+      rows.push(...result.rows);
+      rawPages.push(...result.rawPages);
+    }
+
+    if (config.flags.vertexBigQuery && config.gcp.serviceAccount && config.gcp.bigQueryProject) {
+      const result = await collectRows('vertex-bq', () =>
+        fetchVertexSpendViaBigQuery(
+          {
+            serviceAccountJson: config.gcp.serviceAccount!,
+            projectId: config.gcp.bigQueryProject!,
+            dataset: config.gcp.bigQueryDataset!,
+            table: config.gcp.bigQueryTable!,
+          },
+          { from, to },
+        ),
+      );
+      rows.push(...result.rows);
+      rawPages.push(...result.rawPages);
+    }
+
+    await Promise.all(rawPages.map((page) => rawStore.put(page)));
+
+    const doId = config.ROLLUP_DO.idFromName('global');
+    const stub = config.ROLLUP_DO.get(doId);
+    const payload = {
+      rows,
+      nowIso: now.toISOString(),
+      caps: config.caps,
+      channels: { slackWebhook: config.slackWebhook, emailWebhook: config.emailWebhook },
+      hardCapWebhook: config.hardCapWebhook,
+      lastError: null,
+    };
+
+    const response = await stub.fetch('https://rollup/update', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Rollup DO update failed: ${response.status} ${text}`);
+    }
+
+    log({ level: 'info', op: 'rollup-update', duration_ms: 0, rows: rows.length });
+  } catch (err) {
+    errorLog({ level: 'error', op: 'scheduled', message: (err as Error).message });
+    const doId = config.ROLLUP_DO.idFromName('global');
+    const stub = config.ROLLUP_DO.get(doId);
+    ctx.waitUntil(
+      stub.fetch('https://rollup/update', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          rows: [],
+          nowIso: now.toISOString(),
+          caps: config.caps,
+          lastError: (err as Error).message,
+        }),
+      }),
+    );
+    throw err;
+  }
+};

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,171 @@
+import { z } from 'zod';
+import type { CapConfig } from './core/types';
+
+type KVNamespace = import('@cloudflare/workers-types').KVNamespace;
+type DurableObjectNamespace = import('@cloudflare/workers-types').DurableObjectNamespace;
+
+const booleanFlag = z
+  .string()
+  .optional()
+  .transform((val): boolean => (val ?? '').toLowerCase() === 'true');
+
+const numberFromString = z
+  .string()
+  .optional()
+  .transform((val): number => {
+    if (!val) return 0;
+    const num = Number(val);
+    if (Number.isNaN(num)) {
+      throw new Error(`Invalid numeric env value: ${val}`);
+    }
+    return num;
+  });
+
+export const configSchema = z.object({
+  ENABLE_OPENAI: booleanFlag,
+  ENABLE_ANTHROPIC: booleanFlag,
+  ENABLE_VERTEX_BILLING_API: booleanFlag,
+  ENABLE_VERTEX_BQ: booleanFlag,
+  CRON_LOOKBACK_HOURS: numberFromString.default(48),
+  OPENAI_API_KEY: z.string().optional(),
+  OPENAI_ORG_ID: z.string().optional(),
+  OPENAI_PROJECT_ID: z.string().optional(),
+  ANTHROPIC_API_KEY: z.string().optional(),
+  ANTHROPIC_ORG_ID: z.string().optional(),
+  GCP_SA_JSON: z.string().optional(),
+  GCP_BILLING_ACCOUNT_ID: z.string().optional(),
+  GCP_BUDGET_NAME: z.string().optional(),
+  GCP_BQ_PROJECT: z.string().optional(),
+  GCP_BQ_DATASET: z.string().optional(),
+  GCP_BQ_TABLE: z.string().optional(),
+  ADMIN_TOKEN: z.string().optional(),
+  SLACK_WEBHOOK_URL: z.string().optional(),
+  ALERT_EMAIL_WEBHOOK: z.string().optional(),
+  ON_HARDCAP_WEBHOOK: z.string().optional(),
+  OPENAI_SOFT_CAP: numberFromString,
+  OPENAI_HARD_CAP: numberFromString,
+  ANTHROPIC_SOFT_CAP: numberFromString,
+  ANTHROPIC_HARD_CAP: numberFromString,
+  VERTEX_SOFT_CAP: numberFromString,
+  VERTEX_HARD_CAP: numberFromString,
+  GLOBAL_SOFT_CAP: numberFromString,
+  GLOBAL_HARD_CAP: numberFromString,
+});
+
+export type FeatureFlags = {
+  openai: boolean;
+  anthropic: boolean;
+  vertexBillingApi: boolean;
+  vertexBigQuery: boolean;
+};
+
+export interface RuntimeBindings {
+  RAW_PAGES: KVNamespace;
+  ROLLUP_DO: DurableObjectNamespace;
+}
+
+export interface RuntimeConfig {
+  flags: FeatureFlags;
+  cronLookbackHours: number;
+  caps: CapConfig;
+  slackWebhook?: string;
+  emailWebhook?: string;
+  hardCapWebhook?: string;
+  adminToken?: string;
+  openai: {
+    apiKey?: string;
+    orgId?: string;
+    projectId?: string;
+  };
+  anthropic: {
+    apiKey?: string;
+    orgId?: string;
+  };
+  gcp: {
+    serviceAccount?: string;
+    billingAccountId?: string;
+    budgetName?: string;
+    bigQueryProject?: string;
+    bigQueryDataset?: string;
+    bigQueryTable?: string;
+  };
+}
+
+export type LoadedEnv = RuntimeConfig & RuntimeBindings;
+
+export const validateCaps = (caps: CapConfig): CapConfig => {
+  const sanitized = { ...caps };
+  Object.entries(sanitized).forEach(([key, value]) => {
+    if (value < 0) {
+      throw new Error(`Cap ${key} cannot be negative.`);
+    }
+  });
+  return sanitized;
+};
+
+export const loadConfig = (env: Record<string, unknown> & Partial<RuntimeBindings>): LoadedEnv => {
+  const parsed = configSchema.parse(env);
+
+  const caps = validateCaps({
+    openaiSoft: parsed.OPENAI_SOFT_CAP,
+    openaiHard: parsed.OPENAI_HARD_CAP,
+    anthropicSoft: parsed.ANTHROPIC_SOFT_CAP,
+    anthropicHard: parsed.ANTHROPIC_HARD_CAP,
+    vertexSoft: parsed.VERTEX_SOFT_CAP,
+    vertexHard: parsed.VERTEX_HARD_CAP,
+    globalSoft: parsed.GLOBAL_SOFT_CAP,
+    globalHard: parsed.GLOBAL_HARD_CAP,
+  });
+
+  const flags: FeatureFlags = {
+    openai: parsed.ENABLE_OPENAI,
+    anthropic: parsed.ENABLE_ANTHROPIC,
+    vertexBillingApi: parsed.ENABLE_VERTEX_BILLING_API,
+    vertexBigQuery: parsed.ENABLE_VERTEX_BQ,
+  };
+
+  if ((flags.openai && !parsed.OPENAI_API_KEY) || (flags.anthropic && !parsed.ANTHROPIC_API_KEY)) {
+    throw new Error('Provider enabled without corresponding API key.');
+  }
+
+  if ((flags.vertexBillingApi || flags.vertexBigQuery) && !parsed.GCP_SA_JSON) {
+    throw new Error('Google provider requires GCP_SA_JSON secret.');
+  }
+
+  if (flags.vertexBillingApi && !parsed.GCP_BUDGET_NAME) {
+    throw new Error('ENABLE_VERTEX_BILLING_API requires GCP_BUDGET_NAME.');
+  }
+
+  if (flags.vertexBigQuery && (!parsed.GCP_BQ_PROJECT || !parsed.GCP_BQ_DATASET || !parsed.GCP_BQ_TABLE)) {
+    throw new Error('ENABLE_VERTEX_BQ requires GCP_BQ_PROJECT, GCP_BQ_DATASET, and GCP_BQ_TABLE.');
+  }
+
+  return {
+    RAW_PAGES: (env as RuntimeBindings).RAW_PAGES,
+    ROLLUP_DO: (env as RuntimeBindings).ROLLUP_DO,
+    flags,
+    cronLookbackHours: parsed.CRON_LOOKBACK_HOURS,
+    caps,
+    slackWebhook: parsed.SLACK_WEBHOOK_URL || undefined,
+    emailWebhook: parsed.ALERT_EMAIL_WEBHOOK || undefined,
+    hardCapWebhook: parsed.ON_HARDCAP_WEBHOOK || undefined,
+    adminToken: parsed.ADMIN_TOKEN || undefined,
+    openai: {
+      apiKey: parsed.OPENAI_API_KEY || undefined,
+      orgId: parsed.OPENAI_ORG_ID || undefined,
+      projectId: parsed.OPENAI_PROJECT_ID || undefined,
+    },
+    anthropic: {
+      apiKey: parsed.ANTHROPIC_API_KEY || undefined,
+      orgId: parsed.ANTHROPIC_ORG_ID || undefined,
+    },
+    gcp: {
+      serviceAccount: parsed.GCP_SA_JSON || undefined,
+      billingAccountId: parsed.GCP_BILLING_ACCOUNT_ID || undefined,
+      budgetName: parsed.GCP_BUDGET_NAME || undefined,
+      bigQueryProject: parsed.GCP_BQ_PROJECT || undefined,
+      bigQueryDataset: parsed.GCP_BQ_DATASET || undefined,
+      bigQueryTable: parsed.GCP_BQ_TABLE || undefined,
+    },
+  };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,12 @@
+import type { ExecutionContext } from '@cloudflare/workers-types';
+import { createApp } from './routes/index';
+import { handleScheduled } from './cron';
+import { RollupDO } from './core/storage';
+
+const app = createApp();
+
+export default {
+  fetch: (request: Request, env: unknown, ctx: ExecutionContext) => app.fetch(request, env, ctx),
+  scheduled: handleScheduled,
+  RollupDO,
+};

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -1,0 +1,90 @@
+import { fetchWithRetry, parseJsonResponse } from '../core/http';
+import type { ProviderFetchOptions, ProviderRawPage, ProviderResult, SpendRow } from '../core/types';
+
+interface AnthropicConfig {
+  apiKey: string;
+  orgId?: string;
+}
+
+interface AnthropicUsageDatum {
+  date: string;
+  model: string;
+  input_tokens?: number;
+  output_tokens?: number;
+  cost_usd?: number;
+}
+
+interface AnthropicResponse {
+  data: AnthropicUsageDatum[];
+  next_page_token?: string;
+}
+
+const API_BASE = 'https://api.anthropic.com/v1/usage';
+
+const makeHeaders = (config: AnthropicConfig): HeadersInit => {
+  const headers: Record<string, string> = {
+    'x-api-key': config.apiKey,
+    'content-type': 'application/json',
+    'anthropic-version': '2023-06-01',
+  };
+  if (config.orgId) {
+    headers['anthropic-org-id'] = config.orgId;
+  }
+  return headers;
+};
+
+const normalize = (data: AnthropicUsageDatum[]): SpendRow[] => {
+  return data.map((datum) => ({
+    provider: 'anthropic',
+    model: datum.model,
+    day: datum.date.slice(0, 10),
+    input_tokens: datum.input_tokens,
+    output_tokens: datum.output_tokens,
+    cost_usd: datum.cost_usd ?? 0,
+    currency: 'USD',
+    source: 'usage_api',
+  }));
+};
+
+export const fetchAnthropicSpend = async (
+  config: AnthropicConfig,
+  options: ProviderFetchOptions,
+): Promise<ProviderResult> => {
+  const headers = makeHeaders(config);
+  const url = new URL(API_BASE);
+  url.searchParams.set('start_date', options.from);
+  url.searchParams.set('end_date', options.to);
+
+  const pages: AnthropicResponse[] = [];
+  const raw: ProviderRawPage<AnthropicResponse>[] = [];
+  let pageToken: string | undefined;
+
+  do {
+    if (pageToken) {
+      url.searchParams.set('page_token', pageToken);
+    }
+    const response = await fetchWithRetry({ request: url.toString(), init: { headers }, fetchImpl: options.fetchImpl });
+    const json = await parseJsonResponse<AnthropicResponse>(response);
+    pages.push(json);
+    raw.push({
+      id: crypto.randomUUID(),
+      provider: 'anthropic',
+      fetchedAt: new Date().toISOString(),
+      window: { from: options.from, to: options.to },
+      payload: json,
+      meta: { endpoint: 'usage' },
+    });
+    pageToken = json.next_page_token;
+  } while (pageToken);
+
+  const rows = normalize(pages.flatMap((page) => page.data ?? []));
+  return { rows, rawPages: raw };
+};
+
+export const anthropicRowsFromRaw = (pages: ProviderRawPage[]): SpendRow[] => {
+  return normalize(
+    pages
+      .filter((page) => page.meta?.endpoint === 'usage' || !page.meta)
+      .flatMap((page) => (page.payload as AnthropicResponse).data ?? []),
+  );
+};

--- a/src/providers/gcp_bigquery.ts
+++ b/src/providers/gcp_bigquery.ts
@@ -1,0 +1,138 @@
+import { formatUtcDate } from '../core/rollups';
+import { fetchWithRetry, parseJsonResponse } from '../core/http';
+import type { ProviderFetchOptions, ProviderRawPage, ProviderResult, SpendRow } from '../core/types';
+import { mintAccessToken } from './google_auth';
+
+interface BigQueryConfig {
+  serviceAccountJson: string;
+  projectId: string;
+  dataset: string;
+  table: string;
+  projectFilter?: string[];
+  labelFilters?: Record<string, string>;
+}
+
+interface BigQueryRowField {
+  v: string | null;
+}
+
+interface BigQueryRow {
+  f: BigQueryRowField[];
+}
+
+interface BigQueryResponse {
+  jobComplete: boolean;
+  rows?: BigQueryRow[];
+  totalRows?: string;
+}
+
+const BIGQUERY_SCOPE = 'https://www.googleapis.com/auth/bigquery';
+
+const buildQuery = (config: BigQueryConfig, options: ProviderFetchOptions): { query: string; parameters: any[] } => {
+  const filters: string[] = ["LOWER(sku.description) LIKE 'vertex ai%'"];
+  const parameters: any[] = [
+    { name: 'from', parameterType: { type: 'STRING' }, parameterValue: { value: options.from } },
+    { name: 'to', parameterType: { type: 'STRING' }, parameterValue: { value: options.to } },
+  ];
+
+  if (config.projectFilter && config.projectFilter.length > 0) {
+    filters.push('project.id IN UNNEST(@projectIds)');
+    parameters.push({
+      name: 'projectIds',
+      parameterType: { type: 'ARRAY', arrayType: { type: 'STRING' } },
+      parameterValue: { arrayValues: config.projectFilter.map((value) => ({ value })) },
+    });
+  }
+
+  if (config.labelFilters) {
+    let index = 0;
+    for (const [key, value] of Object.entries(config.labelFilters)) {
+      index += 1;
+      const keyName = `labelKey${index}`;
+      const valueName = `labelValue${index}`;
+      filters.push(
+        `EXISTS (SELECT 1 FROM UNNEST(labels) AS label${index} WHERE label${index}.key = @${keyName} AND label${index}.value = @${valueName})`,
+      );
+      parameters.push(
+        { name: keyName, parameterType: { type: 'STRING' }, parameterValue: { value: key } },
+        { name: valueName, parameterType: { type: 'STRING' }, parameterValue: { value } },
+      );
+    }
+  }
+
+  const filterClause = filters.length > 0 ? `AND ${filters.join(' AND ')}` : '';
+  const tableRef = `\`${config.dataset}.${config.table}\``;
+  const query = `
+    SELECT
+      FORMAT_DATE('%Y-%m-%d', DATE(usage_start_time)) AS day,
+      SUM(cost) AS cost_usd,
+      ANY_VALUE(currency) AS currency
+    FROM ${tableRef}
+    WHERE DATE(usage_start_time) BETWEEN @from AND @to
+      ${filterClause}
+    GROUP BY day
+    ORDER BY day
+  `;
+
+  return { query, parameters };
+};
+
+const toRows = (rows: BigQueryRow[] | undefined): SpendRow[] => {
+  if (!rows) return [];
+  return rows.map((row) => {
+    const [dayField, costField, currencyField] = row.f;
+    return {
+      provider: 'vertex',
+      day: (dayField?.v as string) ?? formatUtcDate(new Date()),
+      cost_usd: Number(costField?.v ?? 0),
+      currency: ((currencyField?.v as string) ?? 'USD') as 'USD',
+      source: 'bq_export',
+    } satisfies SpendRow;
+  });
+};
+
+export const fetchVertexSpendViaBigQuery = async (
+  config: BigQueryConfig,
+  options: ProviderFetchOptions,
+): Promise<ProviderResult<BigQueryResponse>> => {
+  const token = await mintAccessToken(config.serviceAccountJson, [BIGQUERY_SCOPE], options.fetchImpl);
+  const { query, parameters } = buildQuery(config, options);
+  const response = await fetchWithRetry({
+    request: `https://bigquery.googleapis.com/bigquery/v2/projects/${config.projectId}/queries`,
+    init: {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token.access_token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        useLegacySql: false,
+        query,
+        parameterMode: 'NAMED',
+        queryParameters: parameters,
+      }),
+    },
+    fetchImpl: options.fetchImpl,
+  });
+
+  const result = await parseJsonResponse<BigQueryResponse>(response);
+  return {
+    rows: toRows(result.rows),
+    rawPages: [
+      {
+        id: crypto.randomUUID(),
+        provider: 'vertex',
+        fetchedAt: new Date().toISOString(),
+        window: { from: options.from, to: options.to },
+        payload: result,
+        meta: { endpoint: 'bigquery' },
+      },
+    ],
+  };
+};
+
+export const vertexBigQueryRowsFromRaw = (pages: ProviderRawPage<any>[]): SpendRow[] => {
+  return pages
+    .filter((page) => page.meta?.endpoint === 'bigquery' || !page.meta)
+    .flatMap((page) => toRows((page.payload as BigQueryResponse).rows));
+};

--- a/src/providers/gcp_billing.ts
+++ b/src/providers/gcp_billing.ts
@@ -1,0 +1,110 @@
+import { formatUtcDate } from '../core/rollups';
+import { fetchWithRetry, parseJsonResponse } from '../core/http';
+import type { ProviderFetchOptions, ProviderRawPage, ProviderResult, SpendRow } from '../core/types';
+import { mintAccessToken } from './google_auth';
+
+interface BudgetsResponse {
+  name: string;
+  amountSpend?: { units?: string; nanos?: number };
+  amountSpent?: { units?: string; nanos?: number };
+  amountCommitted?: { units?: string; nanos?: number };
+  amount: { specifiedAmount?: { units?: string; nanos?: number } };
+  budgetFilter?: Record<string, unknown>;
+  allUpdatesRule?: Record<string, unknown>;
+  thresholdRules?: Record<string, unknown>[];
+  currentSpend?: { units?: string; nanos?: number };
+  forecastedSpend?: { units?: string; nanos?: number };
+}
+
+const BUDGET_SCOPE = 'https://www.googleapis.com/auth/cloud-billing.read';
+
+const toAmount = (value?: { units?: string; nanos?: number }): number => {
+  if (!value) return 0;
+  const units = Number(value.units ?? 0);
+  const nanos = Number(value.nanos ?? 0);
+  return units + nanos / 1_000_000_000;
+};
+
+interface BillingConfig {
+  serviceAccountJson: string;
+  budgetName: string;
+}
+
+export const fetchVertexSpendViaBudget = async (
+  config: BillingConfig,
+  options: ProviderFetchOptions,
+): Promise<ProviderResult<BudgetsResponse>> => {
+  const token = await mintAccessToken(config.serviceAccountJson, [BUDGET_SCOPE], options.fetchImpl);
+  const response = await fetchWithRetry({
+    request: `https://billingbudgets.googleapis.com/v1/${config.budgetName}`,
+    init: {
+      headers: {
+        Authorization: `Bearer ${token.access_token}`,
+        'content-type': 'application/json',
+      },
+    },
+    fetchImpl: options.fetchImpl,
+  });
+  const budget = await parseJsonResponse<BudgetsResponse>(response);
+  const now = new Date();
+  const rows: SpendRow[] = [
+    {
+      provider: 'vertex',
+      day: formatUtcDate(now),
+      cost_usd: toAmount(budget.currentSpend ?? budget.amountSpent ?? { units: '0' }),
+      currency: 'USD',
+      source: 'budgets_api',
+    },
+  ];
+  if (budget.forecastedSpend) {
+    rows.push({
+      provider: 'vertex',
+      day: formatUtcDate(now),
+      cost_usd: toAmount(budget.forecastedSpend),
+      currency: 'USD',
+      source: 'budgets_api',
+      model: 'forecast',
+    });
+  }
+
+  return {
+    rows,
+    rawPages: [
+      {
+        id: crypto.randomUUID(),
+        provider: 'vertex',
+        fetchedAt: now.toISOString(),
+        window: { from: options.from, to: options.to },
+        payload: budget,
+        meta: { endpoint: 'budgets' },
+      },
+    ],
+  };
+};
+
+export const vertexBudgetRowsFromRaw = (pages: ProviderRawPage<any>[]): SpendRow[] => {
+  return pages.map((page) => {
+    const budget = page.payload as BudgetsResponse;
+    const now = new Date(page.fetchedAt);
+    const rows: SpendRow[] = [
+      {
+        provider: 'vertex',
+        day: formatUtcDate(now),
+        cost_usd: toAmount(budget.currentSpend ?? budget.amountSpent ?? { units: '0' }),
+        currency: 'USD',
+        source: 'budgets_api',
+      },
+    ];
+    if (budget.forecastedSpend) {
+      rows.push({
+        provider: 'vertex',
+        day: formatUtcDate(now),
+        cost_usd: toAmount(budget.forecastedSpend),
+        currency: 'USD',
+        source: 'budgets_api',
+        model: 'forecast',
+      });
+    }
+    return rows;
+  }).flat();
+};

--- a/src/providers/google_auth.ts
+++ b/src/providers/google_auth.ts
@@ -35,12 +35,7 @@ const pemToArrayBuffer = (pem: string): ArrayBuffer => {
   const sanitized = pem.replace('-----BEGIN PRIVATE KEY-----', '')
     .replace('-----END PRIVATE KEY-----', '')
     .replace(/\s+/g, '');
-  let binary: string;
-  if (typeof atob === 'function') {
-    binary = atob(sanitized);
-  } else {
-    binary = Buffer.from(sanitized, 'base64').toString('binary');
-  }
+  const binary = typeof atob === 'function' ? atob(sanitized) : Buffer.from(sanitized, 'base64').toString('latin1');
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i += 1) {
     bytes[i] = binary.charCodeAt(i);

--- a/src/providers/google_auth.ts
+++ b/src/providers/google_auth.ts
@@ -1,0 +1,109 @@
+import { fetchWithRetry, parseJsonResponse } from '../core/http';
+import type { OAuthTokenResponse } from '../core/types';
+
+interface ServiceAccountKey {
+  client_email: string;
+  private_key: string;
+  token_uri?: string;
+}
+
+const BASE_TOKEN_URI = 'https://oauth2.googleapis.com/token';
+
+const encoder = new TextEncoder();
+
+const base64Encode = (input: Uint8Array | string): string => {
+  if (typeof input === 'string') {
+    if (typeof btoa === 'function') {
+      return btoa(unescape(encodeURIComponent(input)));
+    }
+    return Buffer.from(input, 'utf8').toString('base64');
+  }
+  if (typeof btoa === 'function') {
+    let binary = '';
+    input.forEach((b) => {
+      binary += String.fromCharCode(b);
+    });
+    return btoa(binary);
+  }
+  return Buffer.from(input).toString('base64');
+};
+
+const base64UrlEncode = (input: Uint8Array | string): string =>
+  base64Encode(input).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+
+const pemToArrayBuffer = (pem: string): ArrayBuffer => {
+  const sanitized = pem.replace('-----BEGIN PRIVATE KEY-----', '')
+    .replace('-----END PRIVATE KEY-----', '')
+    .replace(/\s+/g, '');
+  let binary: string;
+  if (typeof atob === 'function') {
+    binary = atob(sanitized);
+  } else {
+    binary = Buffer.from(sanitized, 'base64').toString('binary');
+  }
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+};
+
+const createJwt = async (key: ServiceAccountKey, scopes: string[], now: Date): Promise<string> => {
+  const header = base64UrlEncode(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+  const iat = Math.floor(now.getTime() / 1000);
+  const exp = iat + 3600;
+  const payload = base64UrlEncode(
+    JSON.stringify({
+      iss: key.client_email,
+      scope: scopes.join(' '),
+      aud: key.token_uri ?? BASE_TOKEN_URI,
+      iat,
+      exp,
+    }),
+  );
+
+  const toSign = `${header}.${payload}`;
+  const cryptoKey = await crypto.subtle.importKey(
+    'pkcs8',
+    pemToArrayBuffer(key.private_key),
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      hash: 'SHA-256',
+    },
+    false,
+    ['sign'],
+  );
+
+  const signature = await crypto.subtle.sign('RSASSA-PKCS1-v1_5', cryptoKey, encoder.encode(toSign));
+  const signed = base64UrlEncode(new Uint8Array(signature));
+  return `${toSign}.${signed}`;
+};
+
+export const mintAccessToken = async (
+  serviceAccountJson: string,
+  scopes: string[],
+  fetchImpl?: typeof fetch,
+  now: Date = new Date(),
+): Promise<OAuthTokenResponse> => {
+  const key = JSON.parse(serviceAccountJson) as ServiceAccountKey;
+  if (!key.client_email || !key.private_key) {
+    throw new Error('Invalid service account JSON');
+  }
+  const assertion = await createJwt(key, scopes, now);
+  const body = new URLSearchParams({
+    grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+    assertion,
+  });
+
+  const response = await fetchWithRetry({
+    request: key.token_uri ?? BASE_TOKEN_URI,
+    init: {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    },
+    fetchImpl,
+  });
+
+  return parseJsonResponse<OAuthTokenResponse>(response);
+};

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -1,0 +1,206 @@
+import { formatUtcDate } from '../core/rollups';
+import { fetchWithRetry, parseJsonResponse } from '../core/http';
+import type { ProviderFetchOptions, ProviderRawPage, ProviderResult, SpendRow } from '../core/types';
+
+interface OpenAIConfig {
+  apiKey: string;
+  orgId?: string;
+  projectId?: string;
+}
+
+interface UsageDatum {
+  aggregation_timestamp?: number;
+  model?: string;
+  n_context_tokens_total?: number;
+  n_generated_tokens_total?: number;
+  cost?: { usd?: number };
+  usage?: { total_usage?: number };
+  snapshot_id?: string;
+  time_bucket?: string;
+}
+
+interface UsageResponse {
+  data: UsageDatum[];
+  has_more?: boolean;
+  next_page?: string;
+}
+
+interface CostDatum {
+  model?: string;
+  time_period_start?: string;
+  time_period_end?: string;
+  total_cost?: { amount?: number; currency?: string };
+}
+
+interface CostResponse {
+  data: CostDatum[];
+  has_more?: boolean;
+  next_page?: string;
+}
+
+const API_BASE = 'https://api.openai.com/v1';
+
+const makeHeaders = (config: OpenAIConfig): HeadersInit => {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${config.apiKey}`,
+    'content-type': 'application/json',
+  };
+  if (config.orgId) {
+    headers['OpenAI-Organization'] = config.orgId;
+  }
+  return headers;
+};
+
+const toDay = (datum: UsageDatum | CostDatum): string | undefined => {
+  if ('aggregation_timestamp' in datum && datum.aggregation_timestamp) {
+    return formatUtcDate(new Date(datum.aggregation_timestamp * 1000));
+  }
+  if ('time_bucket' in datum && datum.time_bucket) {
+    return datum.time_bucket.slice(0, 10);
+  }
+  if ('time_period_start' in datum && datum.time_period_start) {
+    return datum.time_period_start.slice(0, 10);
+  }
+  return undefined;
+};
+
+const usageKey = (model: string | undefined, day: string | undefined): string =>
+  `${model ?? 'unknown'}|${day ?? 'unknown'}`;
+
+const fetchPaginated = async <T extends UsageResponse | CostResponse>(
+  url: URL,
+  headers: HeadersInit,
+  endpoint: 'usage' | 'costs',
+  fetchImpl?: typeof fetch,
+): Promise<{ pages: T[]; raw: ProviderRawPage<T>[] }> => {
+  const pages: T[] = [];
+  const raw: ProviderRawPage<T>[] = [];
+  let next: string | undefined;
+  do {
+    if (next) {
+      url.searchParams.set('page', next);
+    }
+    const response = await fetchWithRetry({ request: url.toString(), init: { headers }, fetchImpl });
+    const json = await parseJsonResponse<T>(response);
+    pages.push(json);
+    raw.push({
+      id: crypto.randomUUID(),
+      provider: 'openai',
+      fetchedAt: new Date().toISOString(),
+      window: { from: url.searchParams.get('start_date') ?? '', to: url.searchParams.get('end_date') ?? '' },
+      payload: json,
+      meta: { endpoint },
+    });
+    next = (json as UsageResponse | CostResponse).next_page ?? undefined;
+  } while (next);
+  return { pages, raw };
+};
+
+const normalizeUsage = (pages: UsageResponse[]): Map<string, SpendRow> => {
+  const map = new Map<string, SpendRow>();
+  for (const page of pages) {
+    for (const datum of page.data ?? []) {
+      const day = toDay(datum);
+      const model = datum.model ?? 'unknown';
+      const key = usageKey(model, day);
+      const row = map.get(key) ?? {
+        provider: 'openai',
+        model,
+        day: day ?? 'unknown',
+        cost_usd: 0,
+        currency: 'USD',
+        source: 'usage_api',
+      };
+      if (datum.n_context_tokens_total) {
+        row.input_tokens = (row.input_tokens ?? 0) + datum.n_context_tokens_total;
+      }
+      if (datum.n_generated_tokens_total) {
+        row.output_tokens = (row.output_tokens ?? 0) + datum.n_generated_tokens_total;
+      }
+      if (datum.cost?.usd) {
+        row.cost_usd += datum.cost.usd;
+      }
+      map.set(key, row);
+    }
+  }
+  return map;
+};
+
+const mergeCosts = (map: Map<string, SpendRow>, costPages: CostResponse[]): void => {
+  for (const page of costPages) {
+    for (const datum of page.data ?? []) {
+      const day = toDay(datum);
+      const model = datum.model ?? 'unknown';
+      const key = usageKey(model, day);
+      const existing = map.get(key);
+      const costUsd = datum.total_cost?.amount ?? 0;
+      if (existing) {
+        existing.cost_usd = costUsd;
+        existing.source = existing.source === 'usage_api' ? 'cost_api' : existing.source;
+      } else if (day) {
+        map.set(key, {
+          provider: 'openai',
+          model,
+          day,
+          cost_usd: costUsd,
+          currency: 'USD',
+          source: 'cost_api',
+        });
+      }
+    }
+  }
+};
+
+export const fetchOpenAISpend = async (
+  config: OpenAIConfig,
+  options: ProviderFetchOptions,
+): Promise<ProviderResult> => {
+  const usageUrl = new URL(`${API_BASE}/usage`);
+  usageUrl.searchParams.set('start_date', options.from);
+  usageUrl.searchParams.set('end_date', options.to);
+  if (config.projectId) {
+    usageUrl.searchParams.set('project_id', config.projectId);
+  }
+
+  const headers = makeHeaders(config);
+  const { pages: usagePages, raw: usageRaw } = await fetchPaginated<UsageResponse>(usageUrl, headers, 'usage', options.fetchImpl);
+
+  const costUrl = new URL(`${API_BASE}/costs`);
+  costUrl.searchParams.set('start_date', options.from);
+  costUrl.searchParams.set('end_date', options.to);
+  if (config.projectId) {
+    costUrl.searchParams.set('project_id', config.projectId);
+  }
+
+  const { pages: costPages, raw: costRaw } = await fetchPaginated<CostResponse>(costUrl, headers, 'costs', options.fetchImpl);
+
+  const map = normalizeUsage(usagePages);
+  mergeCosts(map, costPages);
+
+  const rows = Array.from(map.values()).map<SpendRow>((row) => ({
+    ...row,
+    day: row.day,
+    source: row.source ?? 'usage_api',
+    cost_usd: Number(row.cost_usd.toFixed(6)),
+  }));
+
+  return {
+    rows,
+    rawPages: [...usageRaw, ...costRaw],
+  };
+};
+
+export const openAiRowsFromRaw = (pages: ProviderRawPage[]): SpendRow[] => {
+  const usagePages = pages
+    .filter((page) => page.meta?.endpoint === 'usage')
+    .map((page) => page.payload as UsageResponse);
+  const costPages = pages
+    .filter((page) => page.meta?.endpoint === 'costs')
+    .map((page) => page.payload as CostResponse);
+  const map = normalizeUsage(usagePages);
+  mergeCosts(map, costPages);
+  return Array.from(map.values()).map((row) => ({
+    ...row,
+    cost_usd: Number(row.cost_usd.toFixed(6)),
+  }));
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,0 +1,186 @@
+import { Hono } from 'hono';
+import type { Context } from 'hono';
+import { loadConfig } from '../env';
+import type { RuntimeBindings } from '../env';
+import { RawPageStore } from '../core/storage';
+import type { RollupResponse } from '../core/storage';
+import { requireAdmin } from '../core/auth';
+import { dispatchCapAlerts } from '../core/alerts';
+import type { ProviderName, ProviderRawPage, SpendRow } from '../core/types';
+import { openAiRowsFromRaw } from '../providers/openai';
+import { anthropicRowsFromRaw } from '../providers/anthropic';
+import { vertexBudgetRowsFromRaw } from '../providers/gcp_billing';
+import { vertexBigQueryRowsFromRaw } from '../providers/gcp_bigquery';
+
+const providers: ProviderName[] = ['openai', 'anthropic', 'vertex'];
+
+const isProviderName = (value: string): value is ProviderName =>
+  (providers as string[]).includes(value);
+
+const getConfig = (c: Context) =>
+  loadConfig(c.env as unknown as Record<string, unknown> & Partial<RuntimeBindings>);
+
+const getRollupStub = (c: Context) => {
+  const config = getConfig(c);
+  const id = config.ROLLUP_DO.idFromName('global');
+  return { config, stub: config.ROLLUP_DO.get(id) };
+};
+
+const serializeRowsFromRaw = (pages: ProviderRawPage[]): SpendRow[] => {
+  const grouped = pages.reduce<Record<ProviderName, ProviderRawPage[]>>(
+    (acc, page) => {
+      acc[page.provider] = acc[page.provider] ?? [];
+      acc[page.provider].push(page);
+      return acc;
+    },
+    { openai: [], anthropic: [], vertex: [] },
+  );
+  const rows: SpendRow[] = [];
+  if (grouped.openai.length) {
+    rows.push(...openAiRowsFromRaw(grouped.openai));
+  }
+  if (grouped.anthropic.length) {
+    rows.push(...anthropicRowsFromRaw(grouped.anthropic));
+  }
+  if (grouped.vertex.length) {
+    const budgetPages = grouped.vertex.filter((page) => page.meta?.endpoint === 'budgets');
+    const bigQueryPages = grouped.vertex.filter((page) => page.meta?.endpoint === 'bigquery');
+    if (budgetPages.length) {
+      rows.push(...vertexBudgetRowsFromRaw(budgetPages as ProviderRawPage[]));
+    }
+    if (bigQueryPages.length) {
+      rows.push(...vertexBigQueryRowsFromRaw(bigQueryPages as ProviderRawPage[]));
+    }
+  }
+  return rows;
+};
+
+export const createApp = () => {
+  const app = new Hono();
+
+  app.get('/status', async (c) => {
+    const { config, stub } = getRollupStub(c);
+    const response = await stub.fetch('https://rollup/state');
+    const state = response.ok ? ((await response.json()) as RollupResponse) : undefined;
+    return c.json({
+      ok: true,
+      bindings: {
+        hasRawPages: Boolean(config.RAW_PAGES),
+        hasRollup: Boolean(config.ROLLUP_DO),
+      },
+      lastRun: state?.lastRun ?? null,
+      lastError: state?.lastError ?? null,
+      providersEnabled: config.flags,
+    });
+  });
+
+  app.get('/spend', async (c) => {
+    const { stub } = getRollupStub(c);
+    const url = new URL('https://rollup/spend');
+    for (const [key, values] of Object.entries(c.req.queries())) {
+      const value = values.at(-1);
+      if (value) {
+        url.searchParams.set(key, value);
+      }
+    }
+    const response = await stub.fetch(url.toString());
+    if (!response.ok) {
+      return c.json({ ok: false, status: response.status }, response.status as any);
+    }
+    const payload = (await response.json()) as Record<string, unknown>;
+    return c.json(payload);
+  });
+
+  app.post('/test/alert', async (c) => {
+    const config = getConfig(c);
+    if (!config.slackWebhook && !config.emailWebhook && !config.hardCapWebhook) {
+      return c.json({ ok: false, message: 'No alert channels configured' }, { status: 400 });
+    }
+    const now = new Date();
+    const result = await dispatchCapAlerts(
+      {
+        breaches: [
+          {
+            scope: 'global',
+            level: 'soft',
+            threshold: 1,
+            total: 1,
+            triggeredAt: now.toISOString(),
+          },
+        ],
+        totals: { global: 1, openai: 0, anthropic: 0, vertex: 0 },
+      },
+      {
+        channels: { slackWebhook: config.slackWebhook, emailWebhook: config.emailWebhook },
+        hardCapWebhook: config.hardCapWebhook,
+        lastSent: {},
+      },
+      now,
+    );
+    return c.json({ ok: true, results: result.results });
+  });
+
+  app.get('/config', (c) => {
+    const config = getConfig(c);
+    return c.json({
+      flags: config.flags,
+      caps: config.caps,
+      cronLookbackHours: config.cronLookbackHours,
+      providers: {
+        openai: Boolean(config.openai.apiKey),
+        anthropic: Boolean(config.anthropic.apiKey),
+        vertexBillingApi: config.flags.vertexBillingApi,
+        vertexBigQuery: config.flags.vertexBigQuery,
+      },
+    });
+  });
+
+  app.get('/providers/:name/raw', async (c) => {
+    const name = c.req.param('name');
+    if (!isProviderName(name)) {
+      return c.json({ ok: false, message: 'Unknown provider' }, { status: 404 });
+    }
+    const config = getConfig(c);
+    const store = new RawPageStore(config.RAW_PAGES);
+    const cursor = c.req.query('cursor') ?? undefined;
+    const limit = c.req.query('limit');
+    const from = c.req.query('from');
+    const to = c.req.query('to');
+    const list = await store.list(name, cursor, limit ? Number(limit) : undefined);
+    const items = list.items.filter((item) => {
+      if (from && item.window.from && item.window.from < from) return false;
+      if (to && item.window.to && item.window.to > to) return false;
+      return true;
+    });
+    return c.json({ items, cursor: list.cursor });
+  });
+
+  app.post('/admin/recompute', async (c, next) => {
+    const config = getConfig(c);
+    const guard = requireAdmin(config.adminToken);
+    await guard(c, next);
+  }, async (c) => {
+    const config = getConfig(c);
+    const store = new RawPageStore(config.RAW_PAGES);
+    const pages = await store.getAll();
+    const rows = serializeRowsFromRaw(pages);
+    const { stub } = getRollupStub(c);
+    const response = await stub.fetch('https://rollup/update', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        rows,
+        nowIso: new Date().toISOString(),
+        caps: config.caps,
+        replace: true,
+      }),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      return c.json({ ok: false, message: text }, response.status as any);
+    }
+    return c.json({ ok: true, rows: rows.length });
+  });
+
+  return app;
+};

--- a/test/caps.test.ts
+++ b/test/caps.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateCaps, shouldSendAlert, updateAlertTimestamps } from '../src/core/caps';
+import type { CapConfig, SpendRow } from '../src/core/types';
+
+const caps: CapConfig = {
+  openaiSoft: 10,
+  openaiHard: 20,
+  anthropicSoft: 5,
+  anthropicHard: 10,
+  vertexSoft: 0,
+  vertexHard: 0,
+  globalSoft: 25,
+  globalHard: 40,
+};
+
+describe('Cap evaluation', () => {
+  it('detects soft and hard breaches', () => {
+    const rows: SpendRow[] = [
+      { provider: 'openai', day: '2024-01-02', cost_usd: 20, currency: 'USD', source: 'usage_api' },
+      { provider: 'anthropic', day: '2024-01-02', cost_usd: 10, currency: 'USD', source: 'usage_api' },
+    ];
+    const now = new Date('2024-01-15T00:00:00Z');
+    const result = evaluateCaps(rows, caps, now);
+    expect(result.breaches.length).toBeGreaterThan(0);
+    expect(result.breaches.some((b) => b.scope === 'openai' && b.level === 'soft')).toBe(true);
+    expect(result.breaches.some((b) => b.scope === 'anthropic' && b.level === 'soft')).toBe(true);
+    expect(result.breaches.some((b) => b.scope === 'global')).toBe(true);
+  });
+
+  it('debounces alerts by timestamp', () => {
+    const breach = {
+      scope: 'global' as const,
+      level: 'soft' as const,
+      threshold: 10,
+      total: 12,
+      triggeredAt: new Date().toISOString(),
+    };
+    const now = new Date();
+    const eligible = shouldSendAlert([breach], {}, now, 3600_000);
+    expect(eligible).toHaveLength(1);
+    const updated = updateAlertTimestamps({}, eligible, now);
+    const suppressed = shouldSendAlert([breach], updated, now, 3600_000);
+    expect(suppressed).toHaveLength(0);
+  });
+});

--- a/test/cron.test.ts
+++ b/test/cron.test.ts
@@ -1,0 +1,79 @@
+import type { ExecutionContext } from '@cloudflare/workers-types';
+import { describe, expect, it, vi } from 'vitest';
+import { handleScheduled } from '../src/cron';
+
+vi.mock('../src/providers/openai', () => ({
+  fetchOpenAISpend: vi.fn(async () => ({
+    rows: [
+      { provider: 'openai', day: '2024-01-01', cost_usd: 1, currency: 'USD', source: 'usage_api' },
+    ],
+    rawPages: [
+      {
+        id: 'page-1',
+        provider: 'openai',
+        fetchedAt: new Date().toISOString(),
+        window: { from: '2024-01-01', to: '2024-01-02' },
+        payload: { data: [] },
+        meta: { endpoint: 'usage' },
+      },
+    ],
+  })),
+}));
+
+vi.mock('../src/providers/anthropic', () => ({ fetchAnthropicSpend: vi.fn(async () => ({ rows: [], rawPages: [] })) }));
+vi.mock('../src/providers/gcp_billing', () => ({ fetchVertexSpendViaBudget: vi.fn(async () => ({ rows: [], rawPages: [] })) }));
+vi.mock('../src/providers/gcp_bigquery', () => ({ fetchVertexSpendViaBigQuery: vi.fn(async () => ({ rows: [], rawPages: [] })) }));
+
+const createKV = () => {
+  const store = new Map<string, string>();
+  return {
+    put: vi.fn(async (key: string, value: string) => {
+      store.set(key, value);
+    }),
+    list: vi.fn(async () => ({ keys: Array.from(store.keys()).map((name) => ({ name })), list_complete: true })),
+    get: vi.fn(async (key: string) => {
+      const value = store.get(key);
+      return value ? JSON.parse(value) : null;
+    }),
+    storage: store,
+  };
+};
+
+describe('Scheduled handler', () => {
+  it('stores raw pages and updates DO', async () => {
+    const kv = createKV();
+    const doFetch = vi.fn(async () => new Response(JSON.stringify({}), { status: 200 }));
+    const env: any = {
+      RAW_PAGES: kv,
+      ROLLUP_DO: {
+        idFromName: vi.fn(() => 'id'),
+        get: vi.fn(() => ({ fetch: doFetch })),
+      },
+      ENABLE_OPENAI: 'true',
+      ENABLE_ANTHROPIC: 'false',
+      ENABLE_VERTEX_BILLING_API: 'false',
+      ENABLE_VERTEX_BQ: 'false',
+      CRON_LOOKBACK_HOURS: '48',
+      OPENAI_API_KEY: 'sk-test',
+      OPENAI_SOFT_CAP: '0',
+      OPENAI_HARD_CAP: '0',
+      ANTHROPIC_SOFT_CAP: '0',
+      ANTHROPIC_HARD_CAP: '0',
+      VERTEX_SOFT_CAP: '0',
+      VERTEX_HARD_CAP: '0',
+      GLOBAL_SOFT_CAP: '0',
+      GLOBAL_HARD_CAP: '0',
+    };
+
+    const event: any = { scheduledTime: Date.now() };
+    const ctx: ExecutionContext = { waitUntil: vi.fn() } as unknown as ExecutionContext;
+
+    await handleScheduled(event, env, ctx);
+
+    expect(kv.put).toHaveBeenCalled();
+    expect(doFetch).toHaveBeenCalled();
+    const [, init] = doFetch.mock.calls[0] as unknown as [string, RequestInit];
+    const payload = JSON.parse((init?.body as string) ?? '{}');
+    expect(payload.rows).toHaveLength(1);
+  });
+});

--- a/test/providers.anthropic.test.ts
+++ b/test/providers.anthropic.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { fetchAnthropicSpend } from '../src/providers/anthropic';
+
+const makeResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+
+describe('Anthropic provider', () => {
+  it('returns spend rows with tokens', async () => {
+    const page = {
+      data: [
+        { date: '2024-01-01', model: 'claude-3', input_tokens: 10, output_tokens: 5, cost_usd: 0.42 },
+      ],
+    };
+    const fetchImpl = async () => makeResponse(page);
+
+    const result = await fetchAnthropicSpend(
+      { apiKey: 'anthropic-key', orgId: 'org' },
+      { from: '2024-01-01', to: '2024-01-02', fetchImpl },
+    );
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].model).toBe('claude-3');
+    expect(result.rows[0].cost_usd).toBeCloseTo(0.42);
+    expect(result.rawPages).toHaveLength(1);
+  });
+});

--- a/test/providers.gcp_billing.test.ts
+++ b/test/providers.gcp_billing.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchVertexSpendViaBudget } from '../src/providers/gcp_billing';
+
+vi.mock('../src/providers/google_auth', () => ({
+  mintAccessToken: vi.fn(async () => ({ access_token: 'token', expires_in: 3600, token_type: 'Bearer' })),
+}));
+
+const makeResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+
+describe('GCP budgets provider', () => {
+  it('maps current and forecasted spend', async () => {
+    const fetchImpl = async () =>
+      makeResponse({
+        currentSpend: { units: '5', nanos: 0 },
+        forecastedSpend: { units: '7', nanos: 500_000_000 },
+      });
+
+    const result = await fetchVertexSpendViaBudget(
+      { serviceAccountJson: '{}', budgetName: 'projects/x/billingAccounts/y/budgets/z' },
+      { from: '2024-01-01', to: '2024-01-02', fetchImpl },
+    );
+
+    expect(result.rows).toHaveLength(2);
+    const [current, forecast] = result.rows;
+    expect(current.cost_usd).toBeCloseTo(5);
+    expect(forecast.model).toBe('forecast');
+    expect(result.rawPages).toHaveLength(1);
+  });
+});

--- a/test/providers.openai.test.ts
+++ b/test/providers.openai.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { fetchOpenAISpend } from '../src/providers/openai';
+
+const makeResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+
+describe('OpenAI provider', () => {
+  it('merges usage and cost responses', async () => {
+    const usage = {
+      data: [
+        {
+          model: 'gpt-4o',
+          aggregation_timestamp: 1_700_000_000,
+          n_context_tokens_total: 100,
+          n_generated_tokens_total: 50,
+          cost: { usd: 1.23 },
+        },
+      ],
+    };
+    const cost = {
+      data: [
+        {
+          model: 'gpt-4o',
+          time_period_start: '2023-11-14T00:00:00Z',
+          total_cost: { amount: 2.5, currency: 'USD' },
+        },
+      ],
+    };
+
+    const calls: Response[] = [makeResponse(usage), makeResponse(cost)];
+    const fetchImpl = async () => calls.shift()!;
+
+    const result = await fetchOpenAISpend(
+      { apiKey: 'sk-test', orgId: 'org', projectId: 'proj' },
+      { from: '2023-11-14', to: '2023-11-15', fetchImpl },
+    );
+
+    expect(result.rows).toHaveLength(1);
+    const row = result.rows[0];
+    expect(row.cost_usd).toBeCloseTo(2.5);
+    expect(row.input_tokens).toBe(100);
+    expect(row.output_tokens).toBe(50);
+    expect(row.day).toBe('2023-11-14');
+    expect(result.rawPages).toHaveLength(2);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "WebWorker"],
+    "types": ["@cloudflare/workers-types", "vitest/globals"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["src", "test"],
+  "exclude": ["node_modules"]
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,45 @@
+name = "ai-spend-monitor"
+main = "src/index.ts"
+compatibility_date = "2024-09-26"
+# enable node compat for vitest/miniflare usage if needed
+compatibility_flags = ["nodejs_compat"]
+
+[observability]
+logs = "debug"
+
+[triggers]
+crons = ["0 * * * *"]
+
+[[kv_namespaces]]
+binding = "RAW_PAGES"
+id = "00000000000000000000000000000000"
+preview_id = "00000000000000000000000000000000"
+
+[durable_objects]
+bindings = [
+  { name = "ROLLUP_DO", class_name = "RollupDO" }
+]
+
+[vars]
+ENABLE_OPENAI = "true"
+ENABLE_ANTHROPIC = "true"
+ENABLE_VERTEX_BILLING_API = "false"
+ENABLE_VERTEX_BQ = "true"
+OPENAI_SOFT_CAP = "0"
+OPENAI_HARD_CAP = "0"
+ANTHROPIC_SOFT_CAP = "0"
+ANTHROPIC_HARD_CAP = "0"
+VERTEX_SOFT_CAP = "0"
+VERTEX_HARD_CAP = "0"
+GLOBAL_SOFT_CAP = "0"
+GLOBAL_HARD_CAP = "0"
+CRON_LOOKBACK_HOURS = "48"
+ON_HARDCAP_WEBHOOK = ""
+SLACK_WEBHOOK_URL = ""
+ALERT_EMAIL_WEBHOOK = ""
+
+[migrations]
+# placeholder to ensure DO class is registered
+[[migrations]]
+new_classes = ["RollupDO"]
+timestamp = 2024-01-01T00:00:00Z


### PR DESCRIPTION
## Summary
- add typed configuration, durable object rollups, and storage plumbing for AI spend aggregation
- implement provider fetchers, cron ingestion, alerting, and Hono API surface for monitoring
- document deployment steps and add unit tests for providers, caps, and scheduled orchestration

## Testing
- npm run check
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cb5346cfcc832e87dafc7daed12158