### PR TITLE
Fix RollupDO import path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { Env } from './env';
 import { handleScheduled } from './cron';
 import { createApp } from './routes';
 // Import the Durable Object class directly.
-import { RollupDO as RollupDOClass } from './core/rollups';
+import { RollupDO as RollupDOClass } from './core/storage';
 
 // Export the Durable Object class as a named constant.
 // This makes it explicitly discoverable by Wrangler during deployment.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,20 +2,16 @@ import type { ExecutionContext } from '@cloudflare/workers-types';
 import { Env } from './env';
 import { handleScheduled } from './cron';
 import { createApp } from './routes';
-// Import the Durable Object class directly.
-import { RollupDO as RollupDOClass } from './core/storage';
 
-// Export the Durable Object class as a named constant.
-// This makes it explicitly discoverable by Wrangler during deployment.
-export const RollupDO = RollupDOClass;
+// Export the Durable Object class directly, making it discoverable by Wrangler.
+export { RollupDO } from './core/storage';
 
 const apiRouter = createApp();
 
 // Export the Worker handlers.
 export default {
-	fetch: (request: Request, env: Env, ctx: ExecutionContext): Promise<Response> => {
-		return apiRouter.fetch(request, env, ctx);
-	},
-	scheduled: handleScheduled,
+  fetch: (request: Request, env: Env, ctx: ExecutionContext): Promise<Response> => {
+    return apiRouter.fetch(request, env, ctx);
+  },
+  scheduled: handleScheduled,
 };
-


### PR DESCRIPTION
## Summary
- update the Worker entrypoint to import the Rollup durable object from the storage module

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdae3dc698832e826d71aab47847f0